### PR TITLE
Release/v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2024-07-25
+ - [#1](https://github.com/scruplelesswizard/split-tests/pull/1) - Fix typo in readme 
+ - [#2](https://github.com/scruplelesswizard/split-tests/pull/2) - Support complex Glob pattern
+ - [#3](https://github.com/scruplelesswizard/split-tests/commit/63e45cd9bb156011de830768b7601104b6e05025) - Replace deprecated set-output command


### PR DESCRIPTION
Background:

The split-test dependency seems to have been abandoned by the maintainer. While fixes to the deprecation warnings were merged into main, a release tag was never created. The dependency in question is: https://github.com/scruplelesswizard/split-tests

For more information view the asana task related to this PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207883122173502